### PR TITLE
Feature/variable fileupload limit and misc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ ci/variables.yml
 /host_vars/*
 .vault_*
 ansible.config.yml
+ansible.cfg
+hosts

--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -104,6 +104,7 @@ jiskefet_user | sets the name of the remote user to create, default is `'jiskefe
 remote_privileged_user | set the remote privileged user to use, default is `'root'` | 
 deploy_environment | sets the deployment environment of PM2 | value: `'dev'`, `'staging'` or `'prod'`  
 file_upload_limit | sets the file upload limit for the database and API, default is `5` MB| number in MB's, e.g. `1, 2, 3, ...`
+application_name | sets the name of the UI (such as the Welcome screen and document title) and API (such as SWAGGER document title), default is `'Jiskefet'` |
 use_hostname_as_remote_address | boolean to tell ansible to use the hostname, default is set to `false`. If set to `true`, ansible will overwrite the value at `ansible_remote_address` | value: `true` or `false`.  **Note: if set to `true`, this variable takes precedence over `custom_ansible_remote_address`**
 custom_ansible_remote_address | field to set the url of the remote, default value is the result of ansible command `ansible_default_ipv4.address` and it will overwrite the value at `ansible_remote_address`| 
 ansible_remote_address | this field is used by ansible to deploy to the remotes. The value of this fields is set by either the variable `custom_ansible_remote_address` or `use_hostname_as_remote_address`| **Note: Do not assign anything to this variable, since it will be overwritten.**

--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -103,6 +103,7 @@ Name | Explanation | possible values/ examples
 jiskefet_user | sets the name of the remote user to create, default is `'jiskefet'` | 
 remote_privileged_user | set the remote privileged user to use, default is `'root'` | 
 deploy_environment | sets the deployment environment of PM2 | value: `'dev'`, `'staging'` or `'prod'`  
+file_upload_limit | sets the file upload limit for the database and API, default is `5` MB| number in MB's, e.g. `1, 2, 3, ...`
 use_hostname_as_remote_address | boolean to tell ansible to use the hostname, default is set to `false`. If set to `true`, ansible will overwrite the value at `ansible_remote_address` | value: `true` or `false`.  **Note: if set to `true`, this variable takes precedence over `custom_ansible_remote_address`**
 custom_ansible_remote_address | field to set the url of the remote, default value is the result of ansible command `ansible_default_ipv4.address` and it will overwrite the value at `ansible_remote_address`| 
 ansible_remote_address | this field is used by ansible to deploy to the remotes. The value of this fields is set by either the variable `custom_ansible_remote_address` or `use_hostname_as_remote_address`| **Note: Do not assign anything to this variable, since it will be overwritten.**

--- a/roles/db/templates/my.cnf.j2
+++ b/roles/db/templates/my.cnf.j2
@@ -3,5 +3,6 @@
 [client-server]
 
 [mysqld]
+max-allowed-packet = {{ database_packet_limit }}
 character-set-client-handshake = FALSE
 character-set-server = utf8mb4

--- a/roles/local/tasks/check-variables.yml
+++ b/roles/local/tasks/check-variables.yml
@@ -19,6 +19,13 @@
     that: "ansible_version.full is version_compare('2.5', '>=')"
     msg: "You must update Ansible to at least 2.5 to use this playbook."
 
+- name: Checking if values are of type integer
+  fail:
+    msg: "Variable {{ item.key }} is not an integer"
+  with_items:
+    - { key: file_upload_limit, value: "{{ file_upload_limit }}"}
+  when: ( item.value | int) <= 0
+
 - name: Checking jiskefet_api_general_settings
   fail: 
     msg: "Variable {{ item.key }} has not been filled in"

--- a/roles/local/tasks/set-default-values.yml
+++ b/roles/local/tasks/set-default-values.yml
@@ -15,7 +15,9 @@
 - name: Set facts that will be used in the next task
   set_fact:
     file_upload_limit: "{{ file_upload_limit if ((file_upload_limit is defined) and (file_upload_limit | trim != '')) else 5}}"
-    DATABASE_NAME: "{{ jiskefet_api_general_settings.TYPEORM_DATABASE }}"
+    database_name: "{{ jiskefet_api_general_settings.TYPEORM_DATABASE }}"
+    application_name: "{{ application_name if ((application_name is defined) and (application_name | trim != '')) else 'Jiskefet'}}"
+    ansible_remote_address: ""
   delegate_to: "{{ item }}"
   with_items:
     - "{{ groups.all }}"
@@ -40,7 +42,8 @@
       JISKEFET_UI: "{{ repository_branch.JISKEFET_UI if ((repository_branch is defined) and (repository_branch.JISKEFET_UI is defined) and (repository_branch.JISKEFET_UI | trim != '')) else 'master'}}"
     USE_CERN_SSO: "{{ USE_CERN_SSO if ((USE_CERN_SSO is defined) and (USE_CERN_SSO | trim != '')) else 'false'}}"
     jiskefet_api_general_settings: 
-      FILE_UPLOAD_LIMIT: "{{ ( file_upload_limit | int ) * 1024 * 1024 }}"
+      FILE_UPLOAD_LIMIT: "{{ file_upload_limit }}"
+      APPLICATION_NAME: "{{ jiskefet_api_general_settings.APPLICATION_NAME if ((jiskefet_api_general_settings.APPLICATION_NAME is defined) and (jiskefet_api_general_settings.APPLICATION_NAME | trim != '')) else '{{ application_name }}' }}"
       USE_API_BASE_PATH: "{{ jiskefet_api_general_settings.USE_API_BASE_PATH if ((jiskefet_api_general_settings.USE_API_BASE_PATH is defined) and (jiskefet_api_general_settings.USE_API_BASE_PATH | trim != '')) else 'true'}}"
       PORT: "{{ jiskefet_api_general_settings.PORT if ((jiskefet_api_general_settings.PORT is defined) and (jiskefet_api_general_settings.PORT | trim != '')) else 3000}}"
       # TYPEORM_HOST: "{{ jiskefet_api_general_settings.TYPEORM_HOST if ((jiskefet_api_general_settings.TYPEORM_HOST is defined) and (jiskefet_api_general_settings.TYPEORM_HOST | trim != '')) else ansible_default_ipv4.address }}"
@@ -54,10 +57,13 @@
     jiskefet_api_optional_settings:
       # TEST_DB_HOST: "{{ jiskefet_api_optional_settings.TEST_DB_HOST if ((jiskefet_api_optional_settings.TEST_DB_HOST is defined) and (jiskefet_api_optional_settings.TEST_DB_HOST | trim != '')) else ansible_default_ipv4.address }}"
       TEST_DB_CONNECTION: "{{ jiskefet_api_optional_settings.TEST_DB_CONNECTION if ((jiskefet_api_optional_settings.TEST_DB_CONNECTION is defined) and (jiskefet_api_optional_settings.TEST_DB_CONNECTION | trim != '')) else 'mysql'}}"
-      TEST_DB_DATABASE: "{{ jiskefet_api_optional_settings.TEST_DB_DATABASE if ((jiskefet_api_optional_settings.TEST_DB_DATABASE is defined) and (jiskefet_api_optional_settings.TEST_DB_DATABASE | trim != '')) else 'test_{{ DATABASE_NAME }}'}}"
+      TEST_DB_DATABASE: "{{ jiskefet_api_optional_settings.TEST_DB_DATABASE if ((jiskefet_api_optional_settings.TEST_DB_DATABASE is defined) and (jiskefet_api_optional_settings.TEST_DB_DATABASE | trim != '')) else 'test_{{ database_name }}'}}"
       TEST_DB_PORT: "{{ jiskefet_api_optional_settings.TEST_DB_PORT if ((jiskefet_api_optional_settings.TEST_DB_PORT is defined) and (jiskefet_api_optional_settings.TEST_DB_PORT | trim != '')) else 3306}}"
       TEST_DB_SYNCHRONIZE: "{{ jiskefet_api_optional_settings.TEST_DB_SYNCHRONIZE if ((jiskefet_api_optional_settings.TEST_DB_SYNCHRONIZE is defined) and (jiskefet_api_optional_settings.TEST_DB_SYNCHRONIZE | trim != '')) else 'true'}}"
       TEST_DB_LOGGING: "{{ jiskefet_api_optional_settings.TEST_DB_LOGGING if ((jiskefet_api_optional_settings.TEST_DB_LOGGING is defined) and (jiskefet_api_optional_settings.TEST_DB_LOGGING | trim != '')) else 'true'}}"
+    jiskefet_ui_settings:
+      APPLICATION_NAME: "{{ jiskefet_ui_settings.APPLICATION_NAME if ((jiskefet_ui_settings.APPLICATION_NAME is defined) and (jiskefet_ui_settings.APPLICATION_NAME | trim != '')) else '{{ application_name }}' }}"
+      FILE_UPLOAD_LIMIT: "{{ file_upload_limit }}"
   delegate_to: "{{ item }}"
   with_items:
     - "{{ groups.all }}"

--- a/roles/local/tasks/set-default-values.yml
+++ b/roles/local/tasks/set-default-values.yml
@@ -12,8 +12,9 @@
     vault_ansible_ssh_pass: ''
   delegate_to: localhost
 
-- name: Set database name as a fact
+- name: Set facts that will be used in the next task
   set_fact:
+    file_upload_limit: "{{ file_upload_limit if ((file_upload_limit is defined) and (file_upload_limit | trim != '')) else 5}}"
     DATABASE_NAME: "{{ jiskefet_api_general_settings.TYPEORM_DATABASE }}"
   delegate_to: "{{ item }}"
   with_items:
@@ -30,7 +31,7 @@
     jiskefet_user: "{{ jiskefet_user if ((jiskefet_user is defined) and (jiskefet_user | trim != '')) else 'jiskefet'}}"
     remote_privileged_user: "{{ remote_privileged_user if ((remote_privileged_user is defined) and (remote_privileged_user | trim != '')) else 'root'}}"
     deploy_environment: "{{ deploy_environment if ((deploy_environment is defined) and (deploy_environment | trim != '')) else 'prod'}}"
-    file_upload_limit: "{{ file_upload_limit if ((file_upload_limit is defined) and (file_upload_limit | trim != '')) else 5}}"
+    database_packet_limit: "{{ ( file_upload_limit | int ) * 1024 * 1024 * 1.5 }}"
     remote_repository_url:
       JISKEFET_API: "{{ remote_repository_url.JISKEFET_API if ((remote_repository_url is defined) and (remote_repository_url.JISKEFET_API is defined) and (remote_repository_url.JISKEFET_API | trim != '')) else 'https://github.com/SoftwareForScience/jiskefet-api.git'}}"
       JISKEFET_UI: "{{ remote_repository_url.JISKEFET_UI if ((remote_repository_url is defined) and (remote_repository_url.JISKEFET_UI is defined) and (remote_repository_url.JISKEFET_UI | trim != '')) else 'https://github.com/SoftwareForScience/jiskefet-ui.git'}}"
@@ -39,6 +40,7 @@
       JISKEFET_UI: "{{ repository_branch.JISKEFET_UI if ((repository_branch is defined) and (repository_branch.JISKEFET_UI is defined) and (repository_branch.JISKEFET_UI | trim != '')) else 'master'}}"
     USE_CERN_SSO: "{{ USE_CERN_SSO if ((USE_CERN_SSO is defined) and (USE_CERN_SSO | trim != '')) else 'false'}}"
     jiskefet_api_general_settings: 
+      FILE_UPLOAD_LIMIT: "{{ ( file_upload_limit | int ) * 1024 * 1024 }}"
       USE_API_BASE_PATH: "{{ jiskefet_api_general_settings.USE_API_BASE_PATH if ((jiskefet_api_general_settings.USE_API_BASE_PATH is defined) and (jiskefet_api_general_settings.USE_API_BASE_PATH | trim != '')) else 'true'}}"
       PORT: "{{ jiskefet_api_general_settings.PORT if ((jiskefet_api_general_settings.PORT is defined) and (jiskefet_api_general_settings.PORT | trim != '')) else 3000}}"
       # TYPEORM_HOST: "{{ jiskefet_api_general_settings.TYPEORM_HOST if ((jiskefet_api_general_settings.TYPEORM_HOST is defined) and (jiskefet_api_general_settings.TYPEORM_HOST | trim != '')) else ansible_default_ipv4.address }}"
@@ -56,19 +58,6 @@
       TEST_DB_PORT: "{{ jiskefet_api_optional_settings.TEST_DB_PORT if ((jiskefet_api_optional_settings.TEST_DB_PORT is defined) and (jiskefet_api_optional_settings.TEST_DB_PORT | trim != '')) else 3306}}"
       TEST_DB_SYNCHRONIZE: "{{ jiskefet_api_optional_settings.TEST_DB_SYNCHRONIZE if ((jiskefet_api_optional_settings.TEST_DB_SYNCHRONIZE is defined) and (jiskefet_api_optional_settings.TEST_DB_SYNCHRONIZE | trim != '')) else 'true'}}"
       TEST_DB_LOGGING: "{{ jiskefet_api_optional_settings.TEST_DB_LOGGING if ((jiskefet_api_optional_settings.TEST_DB_LOGGING is defined) and (jiskefet_api_optional_settings.TEST_DB_LOGGING | trim != '')) else 'true'}}"
-  delegate_to: "{{ item }}"
-  with_items:
-    - "{{ groups.all }}"
-    - localhost
-  delegate_facts: true
-
-  # The database_packet_limit variable is 1.5 times the size of the file_upload_limit.
-  # This is a work around for the 'packet too large' error when uploading packets smaller than "{{ file_upload_limit }}".
-- name: Set database upload limit 
-  set_fact:
-    database_packet_limit: "{{ ( file_upload_limit | int ) * 1024 * 1024 * 1.5 }}"
-    jiskefet_api_general_settings:
-      FILE_UPLOAD_LIMIT: "{{ ( file_upload_limit | int ) * 1024 * 1024 }}"
   delegate_to: "{{ item }}"
   with_items:
     - "{{ groups.all }}"

--- a/roles/local/tasks/set-default-values.yml
+++ b/roles/local/tasks/set-default-values.yml
@@ -30,6 +30,7 @@
     jiskefet_user: "{{ jiskefet_user if ((jiskefet_user is defined) and (jiskefet_user | trim != '')) else 'jiskefet'}}"
     remote_privileged_user: "{{ remote_privileged_user if ((remote_privileged_user is defined) and (remote_privileged_user | trim != '')) else 'root'}}"
     deploy_environment: "{{ deploy_environment if ((deploy_environment is defined) and (deploy_environment | trim != '')) else 'prod'}}"
+    file_upload_limit: "{{ file_upload_limit if ((file_upload_limit is defined) and (file_upload_limit | trim != '')) else 5}}"
     remote_repository_url:
       JISKEFET_API: "{{ remote_repository_url.JISKEFET_API if ((remote_repository_url is defined) and (remote_repository_url.JISKEFET_API is defined) and (remote_repository_url.JISKEFET_API | trim != '')) else 'https://github.com/SoftwareForScience/jiskefet-api.git'}}"
       JISKEFET_UI: "{{ remote_repository_url.JISKEFET_UI if ((remote_repository_url is defined) and (remote_repository_url.JISKEFET_UI is defined) and (remote_repository_url.JISKEFET_UI | trim != '')) else 'https://github.com/SoftwareForScience/jiskefet-ui.git'}}"
@@ -60,4 +61,16 @@
     - "{{ groups.all }}"
     - localhost
   delegate_facts: true
-  
+
+  # The database_packet_limit variable is 1.5 times the size of the file_upload_limit.
+  # This is a work around for the 'packet too large' error when uploading packets smaller than "{{ file_upload_limit }}".
+- name: Set database upload limit 
+  set_fact:
+    database_packet_limit: "{{ ( file_upload_limit | int ) * 1024 * 1024 * 1.5 }}"
+    jiskefet_api_general_settings:
+      FILE_UPLOAD_LIMIT: "{{ ( file_upload_limit | int ) * 1024 * 1024 }}"
+  delegate_to: "{{ item }}"
+  with_items:
+    - "{{ groups.all }}"
+    - localhost
+  delegate_facts: true

--- a/roles/local/tasks/set-default-values.yml
+++ b/roles/local/tasks/set-default-values.yml
@@ -31,7 +31,7 @@
     jiskefet_user: "{{ jiskefet_user if ((jiskefet_user is defined) and (jiskefet_user | trim != '')) else 'jiskefet'}}"
     remote_privileged_user: "{{ remote_privileged_user if ((remote_privileged_user is defined) and (remote_privileged_user | trim != '')) else 'root'}}"
     deploy_environment: "{{ deploy_environment if ((deploy_environment is defined) and (deploy_environment | trim != '')) else 'prod'}}"
-    database_packet_limit: "{{ ( file_upload_limit | int ) * 1024 * 1024 * 1.5 }}"
+    database_packet_limit: "{{ (( file_upload_limit | int ) * 1024 * 1024 * 1.5) | int | round }}" # rounding the numbers
     remote_repository_url:
       JISKEFET_API: "{{ remote_repository_url.JISKEFET_API if ((remote_repository_url is defined) and (remote_repository_url.JISKEFET_API is defined) and (remote_repository_url.JISKEFET_API | trim != '')) else 'https://github.com/SoftwareForScience/jiskefet-api.git'}}"
       JISKEFET_UI: "{{ remote_repository_url.JISKEFET_UI if ((remote_repository_url is defined) and (remote_repository_url.JISKEFET_UI is defined) and (remote_repository_url.JISKEFET_UI | trim != '')) else 'https://github.com/SoftwareForScience/jiskefet-ui.git'}}"

--- a/roles/web/tasks/change-env-variables.yml
+++ b/roles/web/tasks/change-env-variables.yml
@@ -30,12 +30,14 @@
   stat:
     path: /var/lib/jiskefet/jiskefet-api/.env
   register: stat_result
+  become_user: "{{ jiskefet_user }}"
 
 - name: Create .env in jiskefet-api if it does not exist.
   when: stat_result.stat.exists == False 
   file:
     path: /var/lib/jiskefet/jiskefet-api/.env
     state: touch
+  become_user: "{{ jiskefet_user }}"
 
 - name: Set USE_CERN_SSO flag for jiskefet-api .env
   lineinfile:

--- a/roles/web/tasks/nginx.yml
+++ b/roles/web/tasks/nginx.yml
@@ -42,6 +42,15 @@
     dest: /etc/nginx/nginx.conf
   become_method: sudo
 
+- name: Change owner of folder /var/lib/nginx to {{ jiskefet_user }}
+  file:
+    path: /var/lib/nginx
+    state: directory
+    recurse: yes
+    owner: "{{ jiskefet_user }}"
+    group: "{{ jiskefet_user }}"
+  become_method: sudo
+
 - name: Test NGiNX config
   command: nginx -T
   become_method: sudo

--- a/roles/web/tasks/pm2.yml
+++ b/roles/web/tasks/pm2.yml
@@ -44,10 +44,18 @@
     port: "{{ jiskefet_api_general_settings.PORT }}"
     delay: 10
     timeout: 50
-    msg: 
-    - "API is unable to start, please ssh to host:{{ play_hosts }} and run command `$ pm2 logs PM2 --lines 30` to view the error(s)"
-    - "PM2 is unable to create the startup process."
-    - "Please run the application again after solving the problem in order to let PM2 create the startup process."
+  register: wait_for_output
+  ignore_errors: yes
+
+- name: print error when API is not running on port {{ jiskefet_api_general_settings.PORT }}
+  vars:
+    msg: |
+        API is unable to start, please ssh to host:{{ play_hosts }} and run command `$ pm2 logs PM2 --lines 30` to view the error(s).
+        If the error(s) are not visible in the PM2 logs, please go to the directory of the API and run the command `$ npm run start` to view the error(s).
+        Please run the ansible-playbook again after resolving the errors in order to let PM2 create the startup process.
+  debug:
+    msg: "{{ msg.split('\n') }}"
+  failed_when: wait_for_output.failed == true
 
 - name: save current pm2 processes
   command: pm2 save

--- a/roles/web/tasks/pm2.yml
+++ b/roles/web/tasks/pm2.yml
@@ -43,7 +43,11 @@
   wait_for:
     port: "{{ jiskefet_api_general_settings.PORT }}"
     delay: 10
-    msg: "API is unable to start, please ssh to host:{{ play_hosts }} and run command `$ pm2 logs PM2 --lines 30` to view the error(s)"
+    timeout: 50
+    msg: 
+    - "API is unable to start, please ssh to host:{{ play_hosts }} and run command `$ pm2 logs PM2 --lines 30` to view the error(s)"
+    - "PM2 is unable to create the startup process."
+    - "Please run the application again after solving the problem in order to let PM2 create the startup process."
 
 - name: save current pm2 processes
   command: pm2 save

--- a/roles/web/templates/nginx.conf.j2
+++ b/roles/web/templates/nginx.conf.j2
@@ -10,8 +10,6 @@
 #   * Official English Documentation: http://nginx.org/en/docs/
 #   * Official Russian Documentation: http://nginx.org/ru/docs/
 
-# original user
-# user nginx;
 user {{ jiskefet_user }};
 worker_processes auto;
 error_log /var/log/nginx/error.log;

--- a/roles/web/templates/proxy.conf.j2
+++ b/roles/web/templates/proxy.conf.j2
@@ -35,7 +35,7 @@ server {
         add_header Content-Security-Policy {{ allow_csp_payload }};
     }
 
-    ## reverse proxy
+    ## reverse proxy 
     location /api/ {
         proxy_pass http://localhost:{{ jiskefet_api_general_settings.PORT }}/;
         proxy_http_version 1.1;
@@ -43,6 +43,7 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+        client_max_body_size {{ file_upload_limit }}; # Setting the file upload limit for the API
     }
 
     ## Media: images, icons, video, audio, HTC

--- a/roles/web/templates/proxy.conf.j2
+++ b/roles/web/templates/proxy.conf.j2
@@ -6,12 +6,6 @@
 #  * copied verbatim in the file "LICENSE"
 #  */
 
-## upstream is used for defining a webserver cluster http://nginx.org/en/docs/http/ngx_http_upstream_module.html 
-# upstream my_http_servers {
-#     # Nodejs app upstream
-#     server localhost:3000;
-# }
-
 server {
     ## port to listen on
     listen 80;
@@ -26,8 +20,6 @@ server {
 
     ## when root is accessed, go to whatever is specified in block
     location / {
-        # root /var/lib/jiskefet/jiskefet-ui;
-        # index src/index.html;
         autoindex on;
         try_files $uri /src/index.html; # used for not resolving the oauth callback in url /callback
         proxy_set_header Host $host;
@@ -43,7 +35,7 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
-        client_max_body_size {{ file_upload_limit }}; # Setting the file upload limit for the API
+        client_max_body_size {{ (file_upload_limit | int) * 1024 * 1024 }}; # Setting the file upload limit for the API
     }
 
     ## Media: images, icons, video, audio, HTC


### PR DESCRIPTION
In order to test this branch, please set the following fields in the `ansible.config.yml`:
```yaml
repository_branch:
  JISKEFET_API: feature/variable-fileupload-limit-and-misc
  JISKEFET_UI: feature/variable-fileupload-limit-and-misc
```
Related to [PR of jiskefet-api](https://github.com/SoftwareForScience/jiskefet-api/pull/71)
Related to [PR of jiskefet-ui](https://github.com/SoftwareForScience/jiskefet-ui/pull/67)
## Added:
-Two new configuration fields have been added:
1. file_upload_limit: this is used to set the upload limit in MB's
2. application_name: set a custom application name, default is `'Jiskefet'` if left empty.

## Fixed:
- ~/jiskefet-api/.env now has the correct owner
- /api/doc/ is now reachable

## Improved:
- Clarified error when API is not running.
